### PR TITLE
Admins can add other admins

### DIFF
--- a/app/controllers/admin/pending_stores_controller.rb
+++ b/app/controllers/admin/pending_stores_controller.rb
@@ -1,6 +1,6 @@
 class Admin::PendingStoresController < ApplicationController
   def index
-    @pending_stores = Store.where(status: "pending")
+    @pending_stores = Store.where(status: "pending").decorate
   end
 
   def show

--- a/app/controllers/admin/user_roles_controller.rb
+++ b/app/controllers/admin/user_roles_controller.rb
@@ -4,6 +4,21 @@ class Admin::UserRolesController < ApplicationController
     @users = @store.users
   end
 
+  def show
+    @user = User.find_by(email: params["q"])
+    @store = Store.find(params["id"])
+  end
+
+  def update
+    store = Store.find(params["store"])
+    if params["role"] == "Business Manager"
+      UserRole.create(user_id: params["id"], store_id: store.id, role_id: 1)
+    else
+      UserRole.create(user_id: params["id"], store_id: store.id, role_id: 2)
+    end
+    redirect_to admin_store_path(store)
+  end
+
   def destroy
     user_role = UserRole.find_by(store: params["store"], user: params["id"])
     user_role.destroy

--- a/app/decorators/store_decorator.rb
+++ b/app/decorators/store_decorator.rb
@@ -1,0 +1,19 @@
+class StoreDecorator < ApplicationDecorator
+  delegate_all
+
+
+  def created_at
+    helpers.content_tag :span, class: 'time' do
+      object.created_at.strftime("%m/%d/%y")
+    end
+  end
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+
+end

--- a/app/views/admin/pending_stores/index.html.erb
+++ b/app/views/admin/pending_stores/index.html.erb
@@ -1,6 +1,8 @@
-
-<ul>
-  <% @pending_stores.each do |store| %>
- <li> <%= link_to store.name, admin_pending_store_path(store)%> </li>
-  <% end %>
-</ul>
+<%= render "admin/shared/admin_side_nav" %>
+<div style="margin-left:16%">
+  <h4>Pending Stores</h4>
+    <% @pending_stores.each do |store| %>
+      <%= link_to store.name, admin_pending_store_path(store)%> -
+      Request made on <%= store.created_at %>
+    <% end %>
+</div>

--- a/app/views/admin/shared/_admin_side_nav.html.erb
+++ b/app/views/admin/shared/_admin_side_nav.html.erb
@@ -4,6 +4,6 @@
   <%= link_to "Manage Account", edit_user_path(current_user), class: "w3-bar-item w3-button" %>
   <%= link_to "Manage Stores", admin_dashboard_path, class: "w3-bar-item w3-button" %>
   <% if current_user.platform_admin? %>
-    <%= link_to "Pending Stores", href: '/admin/pending_stores', class: "w3-bar-item w3-button" %>
+    <a href="/admin/pending_stores" class="w3-bar-item w3-button">Pending Stores</a>
   <% end %>
 </div>

--- a/app/views/admin/shared/_store.html.erb
+++ b/app/views/admin/shared/_store.html.erb
@@ -1,5 +1,5 @@
 <%= image_tag @store.image, class: "logo" %>
 <p class="logo"><%= @store.name %></p>
-<% if @current_user.business_admin? %>
+<% if @current_user.business_admin? || @current_user.platform_admin? %>
   <%= link_to("Update Business Information", edit_admin_store_path(@store), class: "badge badge-pill badge-primary") %>
 <% end %>    

--- a/app/views/admin/user_roles/index.html.erb
+++ b/app/views/admin/user_roles/index.html.erb
@@ -13,4 +13,10 @@
 <hr>
 <i>Add New Admin:</i><br>
 
+<%= form_tag(admin_user_role_path(@store), action: 'show', method: "get") do %>
+  <%= label_tag(:q, "Search user by email:") %>
+  <%= text_field_tag(:q) %>
+  <%= submit_tag("Search") %>
+<% end %>
+
 </div>

--- a/app/views/admin/user_roles/show.html.erb
+++ b/app/views/admin/user_roles/show.html.erb
@@ -1,0 +1,10 @@
+<h4>Search Result:</h4>
+
+<p>Is this the correct user?</p>
+
+<p><%= @user.full_name %><br>
+<%= @user.email %></p>
+
+<%= link_to "Yes, add #{@user.full_name} as a BUSINESS MANAGER for #{@store.name}", admin_user_role_path(@user, role: "Business Manager", store: @store), method: :patch %><br>
+<%= link_to "Yes, add #{@user.full_name} as a BUSINESS ADMIN for #{@store.name}", admin_user_role_path(@user, role: "Business Admin", store: @store), method: :patch %><br>
+<%= link_to "No, this is not the correct user", url_for(:back) %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -5,7 +5,7 @@
   <div class="stores">
     <% @stores.each do |store| %>
       <%= link_to (image_tag(store.image, class: "logo")), admin_store_path(store), class: store.name %><br>
-      <p class="logo"><b><%= store.name %></b></p>
+      <p class="logo"><b><%= store.name %></b> - <i><%= store.status.capitalize %></i></p>
       <% if current_user.platform_admin? %>
         <p class="logo">Platform Admin</p>
       <% else %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,13 +1,4 @@
-<div class="w3-sidebar w3-light-grey w3-bar-block" style="width:15%">
-  <h3 class="w3-bar-item">Admin Dashboard</h3>
-  <h3 class="side-nav"><%= current_user.full_name  %></h3>
-  <%= link_to "Manage Account", edit_user_path(current_user), class: "w3-bar-item w3-button" %>
-  <%= link_to "Manage Stores", admin_dashboard_path, class: "w3-bar-item w3-button" %>
-  <% if current_user.platform_admin? %>
-    <%= link_to "Pending Stores", href: '/admin/pending_stores', class: "w3-bar-item w3-button" %>
-  <% end %>
-
-</div>
+<%= render "admin/shared/admin_side_nav" %>
 <div style="margin-left:16%">
   <h4>My Stores</h4>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,7 @@ Rails.application.routes.draw do
     resources :orders, only: [:index]
     resources :order_items, only: [:update]
     resources :pending_stores, only: [:show, :update]
-    resources :user_roles, only: [:index, :destroy]
+    resources :user_roles, only: [:index, :show, :update, :destroy]
 
 
     resources :stores, only: [:show, :edit, :update] do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -673,8 +673,10 @@ business_managers << User.create(first_name: "Josh", last_name: "Mejia", usernam
   puts "Business Manager #{i+1} created!"
 end
 
+business_manager = Role.create(name: "Business Manager")
+
 stores.zip(business_managers).each do |store, bm|
-  UserRole.create(user: bm, role: Role.create(name: "Business Manager"), store: store)
+  UserRole.create(user: bm, role: business_manager, store: store)
   puts "#{bm.first_name} is now the business manager for #{store.name}!"
 end
 
@@ -687,8 +689,10 @@ business_admins << User.create(first_name: "Ian", last_name: "Douglas", username
   puts "Business Admin #{i+1} created!"
 end
 
+business_admin = Role.create(name: "Business Admin")
+
 stores.zip(business_admins).each do |store, ba|
-  UserRole.create(user: ba, role: Role.create(name: "Business Admin"), store: store)
+  UserRole.create(user: ba, role: business_admin, store: store)
   puts "#{ba.first_name} is now the Business Admin at #{store.name}!"
 end
 

--- a/spec/decorators/store_decorator_spec.rb
+++ b/spec/decorators/store_decorator_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe StoreDecorator do
+end


### PR DESCRIPTION
LIST OF CHANGES:
- Implemented the following feature: Platform admins and business admins can add other admins to their store.
- Fixed some minor issues with links in the Admin Dashboard.


RSPEC GREEN?
YES



*MENTION GROUP MEMBER TO REVIEW PR*
